### PR TITLE
Add mobile touch support

### DIFF
--- a/script.v1.3.js
+++ b/script.v1.3.js
@@ -15,6 +15,53 @@ let wires = [];  // { path, start, end } 객체를 저장할 배열
 // CSS 애니메이션 한 주기(1초) 만큼 녹화하기 위해 사용
 const WIRE_ANIM_DURATION = 1000; // ms
 
+// --- 모바일 터치 기반 드래그 지원 폴리필 ---
+function enableTouchDrag() {
+  let dragEl = null;
+  const data = {};
+  const dt = {
+    setData: (t, v) => data[t] = v,
+    getData: t => data[t]
+  };
+
+  document.addEventListener('touchstart', e => {
+    const target = e.target.closest('[draggable="true"]');
+    if (!target) return;
+    dragEl = target;
+    data.text = '';
+    const ev = new Event('dragstart', { bubbles: true });
+    ev.dataTransfer = dt;
+    target.dispatchEvent(ev);
+  });
+
+  document.addEventListener('touchmove', e => {
+    if (!dragEl) return;
+    const t = e.touches[0];
+    const el = document.elementFromPoint(t.clientX, t.clientY);
+    if (el) {
+      const over = new Event('dragover', { bubbles: true });
+      over.dataTransfer = dt;
+      el.dispatchEvent(over);
+    }
+    e.preventDefault();
+  }, { passive: false });
+
+  document.addEventListener('touchend', e => {
+    if (!dragEl) return;
+    const t = e.changedTouches[0];
+    const dropTarget = document.elementFromPoint(t.clientX, t.clientY);
+    if (dropTarget) {
+      const dropEv = new Event('drop', { bubbles: true });
+      dropEv.dataTransfer = dt;
+      dropTarget.dispatchEvent(dropEv);
+    }
+    const endEv = new Event('dragend', { bubbles: true });
+    endEv.dataTransfer = dt;
+    dragEl.dispatchEvent(endEv);
+    dragEl = null;
+  });
+}
+
 
 
 const levelTitles = {
@@ -542,6 +589,47 @@ function track(ev) {
   el.classList.add("wire-preview");
 }
 
+function trackTouch(e) {
+  const t = e.touches && e.touches[0];
+  if (!t) return;
+  track({ clientX: t.clientX, clientY: t.clientY });
+  e.preventDefault();
+}
+
+function finishTouch(e) {
+  document.removeEventListener("touchmove", trackTouch);
+  document.removeEventListener("touchend", finishTouch);
+  const t = e.changedTouches && e.changedTouches[0];
+  if (!t) return;
+  const target = document.elementFromPoint(t.clientX, t.clientY);
+  finish({ clientX: t.clientX, clientY: t.clientY, target });
+  e.preventDefault();
+}
+
+function gridTouchMove(e) {
+  if (!isWireDrawing) return;
+  if (wireTrace.length === 0) return;
+  const t = e.touches && e.touches[0];
+  if (!t) return;
+  const el = document.elementFromPoint(t.clientX, t.clientY);
+  const cell = el?.closest(".cell");
+  if (!cell) return;
+
+  const idx = parseInt(cell.dataset.index, 10);
+  const lastIdx = Number(wireTrace.at(-1).dataset.index);
+  if (idx === lastIdx) return;
+
+  const path = getInterpolatedIndices(lastIdx, idx);
+  path.forEach(i => {
+    const cellEl = grid.children[i];
+    if (!wireTrace.includes(cellEl)) {
+      cellEl.classList.add("wire-preview");
+      wireTrace.push(cellEl);
+    }
+  });
+  e.preventDefault();
+}
+
 // 셀 인덱스(문자열) → [row, col] 좌표
 function indexToCoord1(idx) {
   const i = +idx;
@@ -559,6 +647,8 @@ function finish(e) {
   // 1) 리스너 해제
   document.removeEventListener("mousemove", track);
   document.removeEventListener("mouseup", finish);
+  document.removeEventListener("touchmove", trackTouch);
+  document.removeEventListener("touchend", finishTouch);
   isMouseDown = false;
   const middle = wireTrace.slice(1, -1);
   if (middle.some(c => c.dataset.type)) {
@@ -1526,6 +1616,7 @@ window.addEventListener("DOMContentLoaded", () => {
     const level = btn.dataset.level;
     btn.textContent = levelTitles[level] ?? `Stage ${level}`;
   });
+  enableTouchDrag();
   const clearedLevels = JSON.parse(localStorage.getItem("clearedLevels") || "[]");
   clearedLevels.forEach(level => {
     const btn = document.querySelector(`.levelBtn[data-level="${level}"]`);
@@ -1987,6 +2078,20 @@ function setupGrid(containerId, rows, cols) {
     document.addEventListener("mouseup", finish);
   });
 
+  grid.addEventListener("touchstart", e => {
+    const cell = e.target.closest('.cell');
+    if (!isWireDrawing || !cell) return;
+
+    const t = cell.dataset.type;
+    if (!t || t === "WIRE") return;
+
+    isMouseDown = true;
+    wireTrace = [cell];
+
+    document.addEventListener("touchmove", trackTouch, { passive: false });
+    document.addEventListener("touchend", finishTouch);
+  }, { passive: false });
+
   grid.addEventListener("mousemove", e => {
     if (!isWireDrawing) return;
     // 커서 바로 밑의 요소 찾기
@@ -2022,6 +2127,8 @@ function setupGrid(containerId, rows, cols) {
     // wire 미리보기 업데이트
     //drawWirePreview(wireTrace);
   });
+
+  grid.addEventListener("touchmove", gridTouchMove, { passive: false });
   grid.addEventListener('click', e => {
     if (!isWireDeleting) return;
     const cell = e.target.closest('.cell');
@@ -2056,6 +2163,7 @@ function setupGrid(containerId, rows, cols) {
   });
   // ——— 그리드 밖 마우스 탈출 시 취소 ———
   grid.addEventListener('mouseleave', cancelWireDrawing);
+  grid.addEventListener('touchcancel', cancelWireDrawing);
 }
 
 function resetCell(cell) {

--- a/style.v1.3.css
+++ b/style.v1.3.css
@@ -108,6 +108,7 @@
     grid-template-columns: repeat(var(--grid-cols, 6), 50px);
     /* 기존 */
     grid-template-rows: repeat(var(--grid-rows, 6), 50px);
+    touch-action: none;
     /* 추가 */
   }
   #gridContainer {
@@ -1375,6 +1376,7 @@
   border: 2px solid black;
   grid-template-columns: repeat(var(--grid-cols, 6), 50px);
   grid-template-rows: repeat(var(--grid-rows, 6), 50px);
+  touch-action: none;
 }
 
 /* 공통: 게임 모드 · 모듈 모드 블록 패널 모두에 적용 */


### PR DESCRIPTION
## Summary
- add polyfill for touch-based drag events
- handle touch events for wire drawing
- prevent scrolling on grids with `touch-action: none`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68844746e4c0833299861aae7c00a8c3