### PR TITLE
Lock orientation to landscape

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,7 @@
   ],
   "start_url": "./index.html",
   "display": "standalone",
+  "orientation": "landscape",
   "theme_color": "#ffffff",
   "background_color": "#ffffff"
 }

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -1247,7 +1247,16 @@ const mainScreen = document.getElementById("firstScreen");
 const levelScreen = document.getElementById("levelScreen");
 const gameScreen = document.getElementById("gameScreen");
 
+function lockOrientationLandscape() {
+  if (screen.orientation && screen.orientation.lock) {
+    screen.orientation.lock('landscape').catch(err => {
+      console.warn('Orientation lock failed:', err);
+    });
+  }
+}
+
 document.getElementById("startBtn").onclick = () => {
+  lockOrientationLandscape();
   renderChapterGrid();
   document.getElementById("firstScreen").style.display = "none";
   document.getElementById("chapterScreen").style.display = "block";


### PR DESCRIPTION
## Summary
- add `orientation: landscape` to manifest
- lock orientation to landscape when the start button is pressed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884713751748332b7e28c3d9bbde033