### PR TITLE
Show error code in login failure alert

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -2641,7 +2641,7 @@ document.addEventListener("DOMContentLoaded", () => {
       } else {
         const provider = new firebase.auth.GoogleAuthProvider();
         firebase.auth().signInWithPopup(provider).catch(err => {
-          alert('로그인에 실패했습니다.');
+          alert(`로그인에 실패했습니다. 코드: ${err.code}, 메시지: ${err.message}`);
           console.error(err);
         });
       }


### PR DESCRIPTION
## Summary
- improve the login error alert so it shows Firebase error code and message

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68858e20ac3083329aa20b4160571d3b