### PR TITLE
Add custom circuit stage and UI tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
         <div></div>
         <button id="manageModulesBtn">모듈 관리</button>
         <div></div>
-        <button id="createProblemBtn">문제 출제</button>
+        <!-- <button id="createProblemBtn">문제 출제</button> -->
         <div></div>
         <button id="copyStatusBtn">📋 공유하기</button>
         <div></div>
@@ -210,6 +210,11 @@
           </table>
           <button id="addTestcaseRowBtn">+ 행 추가</button>
           <button id="computeOutputsBtn">출력 계산</button>
+          <div style="text-align:center; line-height:1.6; margin-top:0.5rem;">
+            <button id="problemWireStatusInfo" class="toggle-key" style="color: darkgreen; font-weight:bold;">Ctrl - 도선 그리기</button>
+            <button id="problemWireDeleteInfo" class="toggle-key" style="color: crimson; font-weight:bold;">Shift - 도선/블록 삭제</button>
+            <button id="problemDeleteAllInfo" class="toggle-key" style="color: crimson; font-weight:bold;">R - 회로 초기화</button>
+          </div>
         </div>
       </div>
       <div style="margin-top:1rem; width:100%; max-width:500px;">


### PR DESCRIPTION
## Summary
- hide main menu problem creation button
- enable mobile toggle buttons on level creation screen
- add new "사용자 정의 회로" stage selectable after clearing stage 1
- unlock user chapter after first chapter completion
- auto-generate testcases for all input combinations

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6886d90bc0c883328e5ec246e93fdae1