### PR TITLE
Add ranking and likes to custom problems

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1712,3 +1712,21 @@ html, body {
     inset 0 -1px 2px rgba(0, 0, 0, 0.05),
     0 1px 2px rgba(0, 0, 0, 0.08);
 }
+
+#userProblemTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+#userProblemTable th,
+#userProblemTable td {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  text-align: center;
+}
+
+#userProblemTable td.probTitle {
+  cursor: pointer;
+  text-align: left;
+}


### PR DESCRIPTION
## Summary
- store creator name when saving custom problem
- track ranking inside each custom problem entry
- keep custom problem key and save ranking upon clear
- show custom problems in table with creator, date, solved count and likes
- allow toggling likes for custom problems
- style table listing of user problems

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886f39152ec83329e26dd5dc05ff5b8