### PR TITLE
Improve user problem list UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,11 +248,11 @@
       <br><br>
       <button id="backToMainBtn">← 메인으로</button>
     </div>
-    <div id="user-problems-screen" style="display:none; padding:2rem; position:relative;">
+    <div id="user-problems-screen" class="screen" style="display:none;">
       <button id="backToChapterFromUserProblems" class="btn-back">← 챕터로</button>
       <h1>📝 사용자 문제</h1>
       <ul id="userProblemList" class="problem-list"></ul>
-      <button id="openProblemCreatorBtn" class="btn-primary" style="position:absolute; bottom:1rem; right:1rem;">문제 만들기</button>
+      <button id="openProblemCreatorBtn" class="btn-primary">문제 만들기</button>
     </div>
     <div id="rankingModal" class="modal" style="display:none;">
       <div class="modal-content">

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -4128,7 +4128,7 @@ function renderUserProblemList() {
           <td>${data.creator || '익명'}</td>
           <td>${new Date(data.timestamp).toLocaleDateString()}</td>
           <td>${solved}</td>
-          <td><span class="likeCount">${likes}</span> <button class="likeBtn" data-key="${child.key}">👍</button></td>`;
+          <td><span class="likeCount">${likes}</span> <button class="likeBtn" data-key="${child.key}" aria-label="좋아요">♥</button></td>`;
         tr.addEventListener('click', e => {
           if(e.target.classList.contains('likeBtn')) return;
           previewUserProblem(child.key);

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1715,8 +1715,11 @@ html, body {
 
 #userProblemTable {
   width: 100%;
+  max-width: 600px;
   border-collapse: collapse;
   margin-top: 1rem;
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 #userProblemTable th,
@@ -1726,7 +1729,34 @@ html, body {
   text-align: center;
 }
 
+#userProblemTable th {
+  font-weight: 600;
+}
+
 #userProblemTable td.probTitle {
   cursor: pointer;
   text-align: left;
+}
+
+.likeBtn {
+  border: none;
+  background: #eee;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.likeBtn:hover {
+  background: #ddd;
+}
+
+#openProblemCreatorBtn {
+  margin-top: auto;
+  background: #007bff;
+  color: #fff;
+}
+
+#openProblemCreatorBtn:hover {
+  background: #0069d9;
 }


### PR DESCRIPTION
## Summary
- style user problem table with translucent background and cell borders
- use button with hover for problem likes
- center "문제 만들기" button at bottom of user problem screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886f5e77be88332bcf3cfdc411234fe