### PR TITLE
Fix viewport height on all screens

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1,5 +1,5 @@
   body {
-    min-height: 150vh;
+    min-height: 100vh;
     margin: 0;
     flex-direction: column;
     justify-content: center;
@@ -32,8 +32,7 @@ html, body {
   #gameScreen {
     display: flex;
     flex-direction: column;
-    height: 100vh;
-    /* 전체 높이 */
+    min-height: 100vh;
     margin: 0;
     /* 혹시 기본 마진 있으면 제거 */
   }
@@ -1278,10 +1277,17 @@ html, body {
 
   #firstScreen {
     /* 이전: .container { display:flex; gap:5rem; } 에서만 정의되어 있었음 */
+    min-height: 100vh;
     justify-content: center;
     /* 가로 중앙 정렬 */
     align-items: flex-start;
     /* 세 카드의 상단을 같은 높이에 맞춤 */
+  }
+
+  #chapterScreen,
+  #levelScreen,
+  #module-editor-screen {
+    min-height: 100vh;
   }
 
   /* ② 메인 카드(#mainScreen) 가 가진 margin:auto 를 수직 여백만 남기도록 변경 */
@@ -1441,7 +1447,10 @@ html, body {
 /* ── 화면(.screen) 공통 ── */
 .screen {
   position: absolute;
-  top: 0; left: 0; right: 0; bottom: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  min-height: 100vh;
   background: rgba(255,255,255,0.95);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- adjust common `.screen` rule so screens stretch at least to the viewport
- ensure chapter, level and editor screens scroll

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886f80444dc8332ab9316a0475cd57d