### PR TITLE
Add grid size customization and validity checks

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,8 +200,11 @@
         </div>
         <div class="rightPanel" style="display:flex; flex-direction:column; gap:0.5rem;">
           <div>
-            입력 <input id="inputCount" type="number" min="1" max="4" value="1" style="width:40px;">
-            출력 <input id="outputCount" type="number" min="1" max="4" value="1" style="width:40px;">
+            입력 <input id="inputCount" type="number" min="1" max="6" value="1" style="width:40px;">
+            출력 <input id="outputCount" type="number" min="1" max="6" value="1" style="width:40px;">
+            <br>
+            행 <input id="gridRows" type="number" min="1" max="15" value="6" style="width:40px;">
+            열 <input id="gridCols" type="number" min="1" max="15" value="6" style="width:40px;">
             <button id="updateIOBtn">적용</button>
           </div>
           <table id="testcaseTable" border="1" style="font-size:0.9rem; text-align:center;">


### PR DESCRIPTION
## Summary
- allow custom grid size and store rows/cols with problems
- show grid size columns in problem lists
- warn that IO/grid changes reset the circuit and invalidate output
- block saving problems when outputs haven't been computed

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68872856c6c48332867a64c198c47e09