### PR TITLE
Add hint system and ranking update

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,6 +263,17 @@
         <div id="rankingList"></div>
       </div>
     </div>
+    <div id="hintModal" class="modal" style="display:none;">
+      <div class="modal-content">
+        <h2>💡 힌트</h2>
+        <div id="hintContent" style="margin-bottom:1rem;"></div>
+        <button id="watchAdBtn" style="margin-bottom:1rem;">광고 보고 힌트 오픈하기</button>
+        <div class="modal-buttons">
+          <button id="openNextHintBtn">다음 힌트</button>
+          <button id="closeHintBtn">닫기</button>
+        </div>
+      </div>
+    </div>
     <!-- 게임 화면 -->
     <div id="gameScreen" style="display:none">
       <h1 id="gameTitle">🧠 Bit Game</h1>
@@ -318,6 +329,7 @@
         <button id="viewSavedBtn">💾 저장된 회로 보기</button>
         <button id="viewRankingBtn">🏆 랭킹 보기</button>
         <button id="showIntroBtn">ℹ️ 스테이지 안내</button>
+        <button id="hintBtn">💡 힌트</button>
         <button id="backToLevelsBtn">← 레벨 선택으로</button>
         <button id="nextStageBtnMenu">다음 스테이지 →</button>
       </div>

--- a/levels.json
+++ b/levels.json
@@ -431,4 +431,51 @@
       ]
     }
   }
+  ,
+  "levelHints": {
+    "stage6": {
+      "hints": [
+        { "type": "설명", "content": "A∨B가 참이지만, A∧B가 거짓일 때만 참을 출력합니다." },
+        { "type": "논리식", "content": "A XOR B = (A∨B)∧~(A∧B) = (A∧~B)∨(~A∧B)" }
+      ]
+    },
+    "stage7": {
+      "hints": [
+        { "type": "설명", "content": "A와 B가 참이거나, B와 C가 참이거나, C와 A가 참일 때만 참을 출력합니다." },
+        { "type": "논리식", "content": "(A∧B)∨(B∧C)∨(C∧A)" }
+      ]
+    },
+    "stage8": {
+      "hints": [
+        { "type": "설명", "content": "XOR 연산은 mod 2 덧셈처럼 작동합니다." },
+        { "type": "논리식", "content": "(A XOR B) XOR C" }
+      ]
+    },
+    "stage9": {
+      "hints": [
+        { "type": "설명", "content": "OUT1, OUT2가 각각 IN1, IN2에 대한 어떤 연산인지 알아내세요." },
+        { "type": "논리식", "content": "OUT1 = A XOR B, OUT2 = A∧B" }
+      ]
+    },
+    "stage10": {
+      "hints": [
+        { "type": "설명", "content": "OUT1, OUT2가 각각 IN1, IN2, IN3에 대한 어떤 연산인지 알아내세요." },
+        { "type": "논리식", "content": "OUT1 = (A∧B)∨(B∧C)∨(C∧A), OUT2 = (A XOR B) XOR C" },
+        { "type": "구현 방법", "content": "A, B, C 대신 A∧B, A∨B, C에 대한 회로를 구성해보세요." }
+      ]
+    },
+    "stage11": {
+      "hints": [
+        { "type": "설명", "content": "OUT1, OUT2, OUT3, OUT4 각각에 대한 회로를 하나로 합치세요." },
+        { "type": "논리식", "content": "OUT1, OUT2, OUT3, OUT4는 IN1, IN2, ~IN1, ~IN2의 AND 연산으로 표현됩니다." }
+      ]
+    },
+    "stage12": {
+      "hints": [
+        { "type": "설명", "content": "삼항 연산자를 활용하세요." },
+        { "type": "설명", "content": "S1, S0를 순차적으로 처리하세요." },
+        { "type": "논리식", "content": "(A,B,S)를 삼항 연산자라고 할 때 ((IN1,IN2,S0),(IN3,IN4,S0),S1)" }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add structured hint data for stages 6–12
- show hint button and modal in game UI
- implement hint cooldown and tracking across devices
- store hint usage in rankings and display column
- sort rankings by hint usage when scores are tied

## Testing
- `node --check script.v1.4.js`


------
https://chatgpt.com/codex/tasks/task_e_6887723a44d88332b2425f7f8cb9f1ba