### PR TITLE
Revamp hint system UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,11 +266,17 @@
     <div id="hintModal" class="modal" style="display:none;">
       <div class="modal-content">
         <h2>💡 힌트</h2>
-        <div id="hintContent" style="margin-bottom:1rem;"></div>
-        <button id="watchAdBtn" style="margin-bottom:1rem;">광고 보고 힌트 오픈하기</button>
+        <div id="hintButtons" class="modal-buttons" style="flex-wrap:wrap; margin-bottom:1rem;"></div>
         <div class="modal-buttons">
-          <button id="openNextHintBtn">다음 힌트</button>
           <button id="closeHintBtn">닫기</button>
+        </div>
+      </div>
+    </div>
+    <div id="hintMessageModal" class="modal" style="display:none;">
+      <div class="modal-content">
+        <div id="hintMessage" style="margin-bottom:1rem;"></div>
+        <div class="modal-buttons">
+          <button id="closeHintMessageBtn">닫기</button>
         </div>
       </div>
     </div>

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1792,3 +1792,9 @@ html, body {
 #userProblemTable tbody tr.solved {
   background-color: #e6ffe6;
 }
+
+/* Hint modal buttons */
+#hintButtons button {
+  min-width: 90px;
+  font-size: 1rem;
+}


### PR DESCRIPTION
## Summary
- redesign hint modal with horizontal hint buttons
- add persistent hint progress via Firebase
- new small modal for hint text
- enable/disable hint buttons based on cooldown

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887794d22a483329098c53dbb6de5ee