### PR TITLE
Fix overflow for chapter/level screens

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1288,7 +1288,11 @@ html, body {
   }
 
   #chapterScreen,
-  #levelScreen,
+  #levelScreen {
+    min-height: auto;
+    overflow-y: auto;
+  }
+
   #module-editor-screen {
     min-height: 100vh;
   }


### PR DESCRIPTION
## Summary
- let chapter and level screens grow beyond viewport height
- keep module editor screen full height

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888389c562c8332b13b7f3009057ddd