### PR TITLE
Hide module management button

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -87,6 +87,11 @@ html, body {
     font-size: 1.2rem;
   }
 
+  /* 모듈 기능 보류에 따라 메인화면의 모듈 관리 버튼 숨김 */
+  #manageModulesBtn {
+    display: none;
+  }
+
   #guestbookArea button {
     margin: 10px;
     padding: 12px 20px;


### PR DESCRIPTION
## Summary
- hide the Module Management button since the feature is postponed

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688887b6656c8332a24bc3b5da15a0a0